### PR TITLE
Fix GPT-5 nano explanation handling indentation

### DIFF
--- a/app.py
+++ b/app.py
@@ -572,8 +572,7 @@ class SentimentAnalyzer:
                 if explanation and st.session_state.explain_mode != "None":
                     if "GPT-5 nano" not in st.session_state.explanations:
                         st.session_state.explanations["GPT-5 nano"] = {}
-                    st.session_state.explan
-                        st.session_state.explanations["GPT-5 nano"][text_idx] = explanation
+                    st.session_state.explanations["GPT-5 nano"][text_idx] = explanation
                 
                 return scores
 


### PR DESCRIPTION
## Summary
- fix the GPT-5 nano explanation storage block so it no longer raises an indentation error

## Testing
- python -m py_compile app.py

------
https://chatgpt.com/codex/tasks/task_e_68d3975c5ec88327a4c9da149563b7ee